### PR TITLE
feat(middleware): add progress lifecycle

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -8,7 +8,7 @@ function repeatFetch(dispatch, action) {
 
 export default (session = {}, server) => ({dispatch}) => next => action => {
   const fetcher = use('fetcher-factory').createFetcher(session, server);
-  const {fetch, initiate, success, failure, data, retry} = action;
+  const {fetch, initiate, success, progress, failure, data, retry} = action;
 
   if (!fetch) {
     return next(action);
@@ -19,7 +19,10 @@ export default (session = {}, server) => ({dispatch}) => next => action => {
   return fetch(fetcher)
     .then(
       response => {
-        if (retry && retry(null, response)) return repeatFetch(dispatch, action);
+        if (retry && retry(null, response)) {
+          dispatch({type: progress, resource: response, ...data});
+          return repeatFetch(dispatch, action);
+        }
 
         return dispatch({type: success, resource: response, ...data});
       },

--- a/test/unit/middleware-test.js
+++ b/test/unit/middleware-test.js
@@ -68,6 +68,7 @@ suite('fetch middleware', () => {
   suite('success', () => {
     const response = any.simpleObject();
     const success = any.string();
+    const progress = any.string();
 
     setup(() => {
       fetcherFactory.withArgs({}).returns(fetcher);
@@ -95,6 +96,17 @@ suite('fetch middleware', () => {
         middlewareFactory()({dispatch})()(detailedAction),
         dispatchedAction
       ).then(() => assert.calledWith(delay.default, seconds(3)));
+    });
+
+    test('that the progress is reported if the `retry` predicate returns `true`', () => {
+      const retry = sinon.stub();
+      const detailedAction = {...action, fetch, initiate, data, retry, progress};
+      const dispatch = sinon.stub();
+      retry.withArgs(null, response).returns(true);
+      dispatch.withArgs(detailedAction).resolves(dispatchedAction);
+
+      return middlewareFactory()({dispatch})()(detailedAction)
+        .then(() => assert.calledWith(dispatch, {type: progress, resource: response, ...data}));
     });
 
     test('that the fetch is not repeated if the `retry` predicate returns `false`', () => {


### PR DESCRIPTION
added progress lifecycle for use when a retry is passed in but the consumer would still like to get
the updated resource each time it is fetched even though the final resource is not yet ready for
whatever reason. an example usecase for this is a job that reports percent complete. we still want
to know when the job is done and thus cant piggyback on success dispatch so consumers can still
control things like loading indication.

BREAKING CHANGE: progress lifecycle will now dispatch a progress action when something is retried